### PR TITLE
Formato para cantidades negativas

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -432,16 +432,19 @@ defmodule Money do
       "Total: $100.00"
   """
   def to_string(%Money{}=money, opts \\ []) do
-    {separator, delimeter, symbol, symbol_on_right, symbol_space, fractional_unit} = get_display_options(money, opts)
+    {separator, delimeter, symbol, symbol_on_right, negative_left, symbol_space, fractional_unit} = get_display_options(money, opts)
     number = format_number(money, separator, delimeter, fractional_unit, money)
     sign = if negative?(money), do: "-"
     space = if symbol_space, do: " "
 
-    parts = if symbol_on_right do
-              [sign, number, space, symbol]
-            else
-              [symbol, space, sign, number]
-            end
+    parts = cond do 
+      symbol_on_right == true ->
+        [sign, number, space, symbol]
+      symbol_on_right == false && negative_left == true ->
+        [sign, symbol, space, number]
+      symbol_on_right == false ->
+        [symbol, space, sign, number]
+    end
     parts |> Enum.join |> String.lstrip
   end
 
@@ -462,15 +465,17 @@ defmodule Money do
 
     default_symbol = Application.get_env(:money, :symbol, true)
     default_symbol_on_right = Application.get_env(:money, :symbol_on_right, false)
+    default_negative_left = Application.get_env(:money, :negative_left, false)
     default_symbol_space = Application.get_env(:money, :symbol_space, false)
     default_fractional_unit = Application.get_env(:money, :fractional_unit, true)
 
     symbol = if Keyword.get(opts, :symbol, default_symbol), do: Currency.symbol(m), else: ""
     symbol_on_right = Keyword.get(opts, :symbol_on_right, default_symbol_on_right)
+    negative_left = Keyword.get(opts, :negative_left, default_negative_left)
     symbol_space = Keyword.get(opts, :symbol_space, default_symbol_space)
     fractional_unit = Keyword.get(opts, :fractional_unit, default_fractional_unit)
 
-    {separator, delimeter, symbol, symbol_on_right, symbol_space, fractional_unit}
+    {separator, delimeter, symbol, symbol_on_right, negative_left, symbol_space, fractional_unit}
   end
 
   defp get_parse_options(opts) do

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -215,6 +215,25 @@ defmodule MoneyTest do
     assert Money.to_string(zar(-1234567890)) == "R-12,345,678.90"
   end
 
+  test "to_string with negative sign to the left side" do
+    try do
+      Application.put_env(:money, :negative_left, false)
+
+      assert Money.to_string(usd(-500), negative_left: true) == "-$5.00"
+      assert Money.to_string(usd(-500)) == "$-5.00"
+    after
+      Application.delete_env(:money, :negative_left)
+    end
+
+    try do
+      Application.put_env(:money, :negative_left, true)
+
+      assert Money.to_string(usd(-500)) == "-$5.00"
+    after
+      Application.delete_env(:money, :negative_left)
+    end
+  end
+
   test "to_string with fractional_unit false" do
     assert Money.to_string(usd(500), fractional_unit: false) == "$5"
     assert Money.to_string(eur(1234), fractional_unit: false) == "€12"

--- a/test/money_test.exs
+++ b/test/money_test.exs
@@ -216,22 +216,13 @@ defmodule MoneyTest do
   end
 
   test "to_string with negative sign to the left side" do
-    try do
-      Application.put_env(:money, :negative_left, false)
 
+      Application.put_env(:money, :negative_left, false)
       assert Money.to_string(usd(-500), negative_left: true) == "-$5.00"
       assert Money.to_string(usd(-500)) == "$-5.00"
-    after
-      Application.delete_env(:money, :negative_left)
-    end
-
-    try do
+  
       Application.put_env(:money, :negative_left, true)
-
       assert Money.to_string(usd(-500)) == "-$5.00"
-    after
-      Application.delete_env(:money, :negative_left)
-    end
   end
 
   test "to_string with fractional_unit false" do


### PR DESCRIPTION
Se agrega una nueva opción a la función _to_string_ ( negative_left ) que cuando son cantidades negativas coloca el signo de menos a la izquierda de $.